### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ author: Robbie Holmes
 
 navbar-links:
   # About Me: "about-me"
-  Podcasts: podcasts
+  Podcasts: /podcasts
   # Resources:
   #   - Beautiful Jekyll: "https://beautifuljekyll.com"
   #   - Learn markdown: "https://www.markdowntutorial.com/"


### PR DESCRIPTION
I think you need a slash here, so pages, like the usds-doge page will have an absolute link to /podcasts, not a relative link.

I didn't test this.